### PR TITLE
Only change blanking time in xfpm_update_blank_time().

### DIFF
--- a/src/xfpm-power.c
+++ b/src/xfpm-power.c
@@ -1431,6 +1431,7 @@ gboolean xfpm_power_has_battery (XfpmPower *power)
 static void
 xfpm_update_blank_time (XfpmPower *power)
 {
+    int prev_timeout, prev_interval, prev_prefer_blanking, prev_allow_exposures;
     Display* display = gdk_x11_display_get_xdisplay(gdk_display_get_default ());
     guint screensaver_timeout;
 
@@ -1445,7 +1446,8 @@ xfpm_update_blank_time (XfpmPower *power)
 
     XFPM_DEBUG ("Timeout: %d", screensaver_timeout);
 
-    XSetScreenSaver(display, screensaver_timeout * 60, 0, DefaultBlanking, DefaultExposures);
+    XGetScreenSaver(display, &prev_timeout, &prev_interval, &prev_prefer_blanking, &prev_allow_exposures);
+    XSetScreenSaver(display, screensaver_timeout * 60, prev_interval, prev_prefer_blanking, prev_allow_exposures);
 }
 
 static void


### PR DESCRIPTION
Do not change other X screensaver arguments (interval, prefer_blanking,
allow_exposures) when changing blanking time.

Get the current values from XGetScreenSaver() call and use them instead
of defaults.

See [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=914544) for an example of a problem with the current default interval/cycle time of 0.